### PR TITLE
cmd/cueckoo: add unity command

### DIFF
--- a/cmd/cueckoo/cmd/cltrigger.go
+++ b/cmd/cueckoo/cmd/cltrigger.go
@@ -1,0 +1,282 @@
+// Copyright 2021 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/google/go-github/v31/github"
+	"golang.org/x/build/gerrit"
+)
+
+var (
+	changeIDRegex = regexp.MustCompile(`(?m)^Change-Id: (.*)$`)
+)
+
+type builder func(payload clTriggerPayload) (github.DispatchRequestOptions, error)
+
+type cltrigger struct {
+	cmd     *Command
+	cfg     *config
+	builder builder
+}
+
+func newCLTrigger(cmd *Command, cfg *config, b builder) *cltrigger {
+	return &cltrigger{
+		cmd:     cmd,
+		cfg:     cfg,
+		builder: b,
+	}
+}
+
+func (c *cltrigger) run() (err error) {
+	var changeIDs []revision
+	args := make(map[string]bool)
+	for _, a := range c.cmd.Flags().Args() {
+		args[a] = true
+	}
+	if flagChange.Bool(c.cmd) {
+		if len(args) == 0 {
+			return fmt.Errorf("must provide at least one change number of ID")
+		}
+		for a := range args {
+			changeIDs = append(changeIDs, revision{
+				changeID: a,
+			})
+		}
+	} else {
+		changeIDs, err = c.deriveChangeIDs(args)
+		if err != nil {
+			return err
+		}
+	}
+	return c.triggerBuilds(changeIDs)
+}
+
+// deriveChangeIDs determines a list of change IDs for the supplied args
+// (if there are any). See the runtrybot docs for an explanation of what
+// is derived. Essentially however we try to follow the semantics of
+// git-codereview:
+//
+// https://pkg.go.dev/golang.org/x/review/git-codereview
+//
+func (c *cltrigger) deriveChangeIDs(args map[string]bool) (res []revision, err error) {
+	// Work out the branchpoint
+	var bp, bpStderr bytes.Buffer
+	bpCmd := exec.Command("git", "codereview", "branchpoint")
+	bpCmd.Stdout = &bp
+	bpCmd.Stderr = &bpStderr
+	if err := bpCmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to run [%v]: %v\n%s", strings.Join(bpCmd.Args, " "), err, bpStderr.String())
+	}
+
+	// Calculate the list of commits that are pending
+	var commitList, clStderr bytes.Buffer
+	logCmd := exec.Command("git", "log", "--pretty=format:%H", "--no-patch", fmt.Sprintf("%s..HEAD", bytes.TrimSpace(bp.Bytes())))
+	logCmd.Stdout = &commitList
+	logCmd.Stderr = &clStderr
+	if err := logCmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to run [%v]: %v\n%s", strings.Join(logCmd.Args, " "), err, clStderr.String())
+	}
+
+	var pendingCommits []*object.Commit
+	for _, line := range strings.Split(string(commitList.String()), "\n") {
+		h := strings.TrimSpace(line)
+		commit, err := c.cfg.repo.CommitObject(plumbing.NewHash(h))
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive commit from %q: %v", h, err)
+		}
+		pendingCommits = append(pendingCommits, commit)
+	}
+
+	if len(pendingCommits) == 0 {
+		return nil, fmt.Errorf("no pending commits")
+	}
+	if args["HEAD"] && len(args) > 1 {
+		return nil, fmt.Errorf("HEAD can only be supplied as an argument by itself")
+	}
+	if !args["HEAD"] && len(pendingCommits) > 1 && len(args) == 0 {
+		return nil, fmt.Errorf("must specify commits as arguments or use HEAD for everything")
+	}
+	if args["HEAD"] || len(args) == 0 && len(pendingCommits) == 1 {
+		// Verify all
+
+		for _, pc := range pendingCommits {
+			changeID, err := getChangeIDFromCommitMsg(pc.Message)
+			if err != nil {
+				return nil, fmt.Errorf("failed to derive change ID: %v", err)
+			}
+
+			res = append(res, revision{
+				changeID: changeID,
+				revision: pc.Hash.String(),
+			})
+		}
+	} else {
+		// We verify each of the arguments
+	EachArg:
+		for h := range args {
+			// Resolve the arg and ensure we have a matching pending commit
+			commit, err := c.cfg.repo.CommitObject(plumbing.NewHash(h))
+			if err != nil {
+				return nil, fmt.Errorf("failed to derive commit from %q: %v", h, err)
+			}
+			for _, pc := range pendingCommits {
+				if commit.Hash == pc.Hash {
+					changeID, err := getChangeIDFromCommitMsg(pc.Message)
+					if err != nil {
+						return nil, fmt.Errorf("failed to derive change ID: %v", err)
+					}
+
+					res = append(res, revision{
+						changeID: changeID,
+						revision: pc.Hash.String(),
+					})
+					continue EachArg
+				}
+			}
+			return nil, fmt.Errorf("commit %v is not a pending commit", h)
+		}
+	}
+	return
+}
+
+type revision struct {
+	changeID string
+	revision string
+}
+
+func (c *cltrigger) triggerBuilds(revs []revision) error {
+	errs := new(errorList)
+	var wg sync.WaitGroup
+
+	for i := range revs {
+		rev := revs[i]
+		wg.Add(1)
+		go func() {
+			var err error
+			defer wg.Done()
+			defer errs.Add(&err)
+			defer recoverError(&err)
+			err = c.triggerBuild(rev)
+		}()
+	}
+
+	wg.Wait()
+	if len(errs.errs) > 0 {
+		var msgs []string
+		for _, e := range errs.errs {
+			msgs = append(msgs, e.Error())
+		}
+		return fmt.Errorf(strings.Join(msgs, "\n"))
+	}
+	return nil
+}
+
+func (c *cltrigger) triggerBuild(rev revision) error {
+	in, err := c.cfg.gerritClient.GetChange(context.Background(), rev.changeID, gerrit.QueryChangesOpt{
+		Fields: []string{"ALL_REVISIONS"},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get current revision information: %v", err)
+	}
+
+	var ref string
+	var commit string
+	if rev.revision != "" {
+		ri, ok := in.Revisions[rev.revision]
+		if !ok {
+			return fmt.Errorf("change %v does not know about revision %v; did you forget to run git codereview mail?", rev.changeID, rev.revision)
+		}
+		ref = ri.Ref
+		commit = rev.revision
+	} else {
+		// find the latest ref
+		type revInfoPair struct {
+			rev string
+			ri  gerrit.RevisionInfo
+		}
+		var revInfoPairs []revInfoPair
+		for rev, ri := range in.Revisions {
+			revInfoPairs = append(revInfoPairs, revInfoPair{
+				rev: rev,
+				ri:  ri,
+			})
+		}
+		sort.Slice(revInfoPairs, func(i, j int) bool {
+			return revInfoPairs[i].ri.PatchSetNumber < revInfoPairs[j].ri.PatchSetNumber
+		})
+		ref = revInfoPairs[len(revInfoPairs)-1].ri.Ref
+		commit = revInfoPairs[len(revInfoPairs)-1].rev
+	}
+
+	payload, err := c.builder(clTriggerPayload{
+		ChangeID: rev.changeID,
+		Ref:      ref,
+		Commit:   commit,
+	})
+	if err != nil {
+		return err
+	}
+	return c.cfg.triggerRepositoryDispatch(payload)
+}
+
+type clTriggerPayload struct {
+	ChangeID string `json:"changeID"`
+	Ref      string `json:"ref"`
+	Commit   string `json:"commit"`
+}
+
+func getChangeIDFromCommitMsg(msg string) (string, error) {
+	matches := changeIDRegex.FindAllStringSubmatch(msg, -1)
+	if len(matches) != 1 || len(matches[0]) != 2 {
+		return "", fmt.Errorf("failed to find Change-Id in commit message")
+	}
+	return matches[0][1], nil
+}
+
+type errorList struct {
+	mu   sync.Mutex
+	errs []error
+}
+
+func (e *errorList) Add(err *error) {
+	if *err == nil {
+		return
+	}
+	e.mu.Lock()
+	e.errs = append(e.errs, *err)
+	e.mu.Unlock()
+}
+
+func (e *errorList) Error() string {
+	panic("do not use; inspect list of errors")
+}
+
+func (e *errorList) Err() error {
+	if len(e.errs) == 0 {
+		return nil
+	}
+	return e
+}

--- a/cmd/cueckoo/cmd/importpr.go
+++ b/cmd/cueckoo/cmd/importpr.go
@@ -33,7 +33,7 @@ func newImportPRCmd(c *Command) *cobra.Command {
 }
 
 func importPRDef(c *Command, args []string) error {
-	cfg, err := loadConfig()
+	cfg, err := loadConfig(targetGitHub)
 	if err != nil {
 		return err
 	}

--- a/cmd/cueckoo/cmd/main.go
+++ b/cmd/cueckoo/cmd/main.go
@@ -75,6 +75,7 @@ func newRootCmd() *Command {
 		newRuntrybotCmd(c),
 		newMirrorCmd(c),
 		newImportPRCmd(c),
+		newUnityCmd(c),
 	}
 
 	for _, sub := range subCommands {

--- a/cmd/cueckoo/cmd/mirror.go
+++ b/cmd/cueckoo/cmd/mirror.go
@@ -30,7 +30,7 @@ func newMirrorCmd(c *Command) *cobra.Command {
 }
 
 func mirrorDef(c *Command, args []string) error {
-	cfg, err := loadConfig()
+	cfg, err := loadConfig(targetGitHub)
 	if err != nil {
 		return err
 	}

--- a/cmd/cueckoo/cmd/payload_test.go
+++ b/cmd/cueckoo/cmd/payload_test.go
@@ -35,7 +35,7 @@ func TestPayloads(t *testing.T) {
 		return dro
 	}
 	testCases := map[string]github.DispatchRequestOptions{
-		"runtrybot": must(buildRuntrybotPayload("hello", runtrybotPayload{
+		"runtrybot": must(buildRunTryBotPayload(clTriggerPayload{
 			ChangeID: "change",
 			Ref:      "ref",
 			Commit:   "commit",
@@ -43,6 +43,14 @@ func TestPayloads(t *testing.T) {
 		"mirror": must(buildMirrorPayload("hello")),
 		"importpr": must(buildImportPRPayload("hello", importPRPayload{
 			PR: 123,
+		})),
+		"unity_versions": must(buildUnityPayload("hello", unityPayload{
+			Versions: "\"v0.3.0-beta.5\"",
+		})),
+		"unity_cl": must(buildUnityPayloadFromCLTrigger(clTriggerPayload{
+			ChangeID: "change",
+			Ref:      "ref",
+			Commit:   "commit",
 		})),
 	}
 

--- a/cmd/cueckoo/cmd/runtrybot.go
+++ b/cmd/cueckoo/cmd/runtrybot.go
@@ -15,20 +15,10 @@
 package cmd
 
 import (
-	"bytes"
-	"context"
 	"fmt"
-	"os/exec"
-	"regexp"
-	"sort"
-	"strings"
-	"sync"
 
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/go-github/v31/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/build/gerrit"
 )
 
 const (
@@ -43,14 +33,14 @@ func newRuntrybotCmd(c *Command) *cobra.Command {
 		Long: `
 Usage of runtrybot:
 
-	runtrybot [-change] [ARGS...]
+	runtrybot [--change] [ARGS...]
 
 When run with no arguments, runtrybot derives a revision and change ID for each
 pending commit in the current branch. If multiple pending commits are found,
 you must either specify which commits to run, or specify HEAD to run the
 trybots for all of them.
 
-If the -change flag is provide, then the list of arguments is interpreted as
+If the --change flag is provide, then the list of arguments is interpreted as
 change numbers or IDs, and the latest revision from each of those changes is
 assumed.
 
@@ -65,258 +55,15 @@ access token only requires "public_repo" scope.
 }
 
 func runtrybotDef(cmd *Command, args []string) error {
-	cfg, err := loadConfig()
+	cfg, err := loadConfig(targetGitHub)
 	if err != nil {
 		return err
 	}
-	r := &runtrybot{
-		cmd: cmd,
-		cfg: cfg,
-	}
+	r := newCLTrigger(cmd, cfg, buildRunTryBotPayload)
 	return r.run()
 }
 
-var (
-	changeIDRegex = regexp.MustCompile(`(?m)^Change-Id: (.*)$`)
-)
-
-type runtrybot struct {
-	cmd *Command
-	cfg *config
-}
-
-func (r *runtrybot) run() (err error) {
-	var changeIDs []revision
-	args := make(map[string]bool)
-	for _, a := range r.cmd.Flags().Args() {
-		args[a] = true
-	}
-	if flagChange.Bool(r.cmd) {
-		if len(args) == 0 {
-			return fmt.Errorf("must provide at least one change number of ID")
-		}
-		for a := range args {
-			changeIDs = append(changeIDs, revision{
-				changeID: a,
-			})
-		}
-	} else {
-		changeIDs, err = r.deriveChangeIDs(args)
-		if err != nil {
-			return err
-		}
-	}
-	return r.triggerBuilds(changeIDs)
-}
-
-// deriveChangeIDs determines a list of change IDs for the supplied args
-// (if there are any). See the runtrybot docs for an explanation of what
-// is derived. Essentially however we try to follow the semantics of
-// git-codereview:
-//
-// https://pkg.go.dev/golang.org/x/review/git-codereview
-//
-func (r *runtrybot) deriveChangeIDs(args map[string]bool) (res []revision, err error) {
-	// Work out the branchpoint
-	var bp, bpStderr bytes.Buffer
-	bpCmd := exec.Command("git", "codereview", "branchpoint")
-	bpCmd.Stdout = &bp
-	bpCmd.Stderr = &bpStderr
-	if err := bpCmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to run [%v]: %v\n%s", strings.Join(bpCmd.Args, " "), err, bpStderr.String())
-	}
-
-	// Calculate the list of commits that are pending
-	var commitList, clStderr bytes.Buffer
-	logCmd := exec.Command("git", "log", "--pretty=format:%H", "--no-patch", fmt.Sprintf("%s..HEAD", bytes.TrimSpace(bp.Bytes())))
-	logCmd.Stdout = &commitList
-	logCmd.Stderr = &clStderr
-	if err := logCmd.Run(); err != nil {
-		return nil, fmt.Errorf("failed to run [%v]: %v\n%s", strings.Join(logCmd.Args, " "), err, clStderr.String())
-	}
-
-	var pendingCommits []*object.Commit
-	for _, line := range strings.Split(string(commitList.String()), "\n") {
-		h := strings.TrimSpace(line)
-		commit, err := r.cfg.repo.CommitObject(plumbing.NewHash(h))
-		if err != nil {
-			return nil, fmt.Errorf("failed to derive commit from %q: %v", h, err)
-		}
-		pendingCommits = append(pendingCommits, commit)
-	}
-
-	if len(pendingCommits) == 0 {
-		return nil, fmt.Errorf("no pending commits")
-	}
-	if args["HEAD"] && len(args) > 1 {
-		return nil, fmt.Errorf("HEAD can only be supplied as an argument by itself")
-	}
-	if !args["HEAD"] && len(pendingCommits) > 1 && len(args) == 0 {
-		return nil, fmt.Errorf("must specify commits as arguments or use HEAD for everything")
-	}
-	if args["HEAD"] || len(args) == 0 && len(pendingCommits) == 1 {
-		// Verify all
-
-		for _, pc := range pendingCommits {
-			changeID, err := getChangeIDFromCommitMsg(pc.Message)
-			if err != nil {
-				return nil, fmt.Errorf("failed to derive change ID: %v", err)
-			}
-
-			res = append(res, revision{
-				changeID: changeID,
-				revision: pc.Hash.String(),
-			})
-		}
-	} else {
-		// We verify each of the arguments
-	EachArg:
-		for h := range args {
-			// Resolve the arg and ensure we have a matching pending commit
-			commit, err := r.cfg.repo.CommitObject(plumbing.NewHash(h))
-			if err != nil {
-				return nil, fmt.Errorf("failed to derive commit from %q: %v", h, err)
-			}
-			for _, pc := range pendingCommits {
-				if commit.Hash == pc.Hash {
-					changeID, err := getChangeIDFromCommitMsg(pc.Message)
-					if err != nil {
-						return nil, fmt.Errorf("failed to derive change ID: %v", err)
-					}
-
-					res = append(res, revision{
-						changeID: changeID,
-						revision: pc.Hash.String(),
-					})
-					continue EachArg
-				}
-			}
-			return nil, fmt.Errorf("commit %v is not a pending commit", h)
-		}
-	}
-	return
-}
-
-type revision struct {
-	changeID string
-	revision string
-}
-
-func (r *runtrybot) triggerBuilds(revs []revision) error {
-	errs := new(errorList)
-	var wg sync.WaitGroup
-
-	for i := range revs {
-		rev := revs[i]
-		wg.Add(1)
-		go func() {
-			var err error
-			defer wg.Done()
-			defer errs.Add(&err)
-			defer recoverError(&err)
-			err = r.triggerBuild(rev)
-		}()
-	}
-
-	wg.Wait()
-	if len(errs.errs) > 0 {
-		var msgs []string
-		for _, e := range errs.errs {
-			msgs = append(msgs, e.Error())
-		}
-		return fmt.Errorf(strings.Join(msgs, "\n"))
-	}
-	return nil
-}
-
-func (r *runtrybot) triggerBuild(rev revision) error {
-	in, err := r.cfg.gerritClient.GetChange(context.Background(), rev.changeID, gerrit.QueryChangesOpt{
-		Fields: []string{"ALL_REVISIONS"},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to get current revision information: %v", err)
-	}
-
-	var ref string
-	var commit string
-	if rev.revision != "" {
-		ri, ok := in.Revisions[rev.revision]
-		if !ok {
-			return fmt.Errorf("change %v does not know about revision %v; did you forget to run git codereview mail?", rev.changeID, rev.revision)
-		}
-		ref = ri.Ref
-		commit = rev.revision
-	} else {
-		// find the latest ref
-		type revInfoPair struct {
-			rev string
-			ri  gerrit.RevisionInfo
-		}
-		var revInfoPairs []revInfoPair
-		for rev, ri := range in.Revisions {
-			revInfoPairs = append(revInfoPairs, revInfoPair{
-				rev: rev,
-				ri:  ri,
-			})
-		}
-		sort.Slice(revInfoPairs, func(i, j int) bool {
-			return revInfoPairs[i].ri.PatchSetNumber < revInfoPairs[j].ri.PatchSetNumber
-		})
-		ref = revInfoPairs[len(revInfoPairs)-1].ri.Ref
-		commit = revInfoPairs[len(revInfoPairs)-1].rev
-	}
-
-	msg := fmt.Sprintf("trybot run for %v", ref)
-	payload, err := buildRuntrybotPayload(msg, runtrybotPayload{
-		ChangeID: rev.changeID,
-		Ref:      ref,
-		Commit:   commit,
-	})
-	if err != nil {
-		return err
-	}
-	return r.cfg.triggerRepositoryDispatch(payload)
-}
-
-type runtrybotPayload struct {
-	ChangeID string `json:"changeID"`
-	Ref      string `json:"ref"`
-	Commit   string `json:"commit"`
-}
-
-func buildRuntrybotPayload(msg string, payload runtrybotPayload) (github.DispatchRequestOptions, error) {
+func buildRunTryBotPayload(payload clTriggerPayload) (github.DispatchRequestOptions, error) {
+	msg := fmt.Sprintf("trybot run for %v", payload.Ref)
 	return buildDispatchPayload(msg, eventTypeRuntrybot, payload)
-}
-
-func getChangeIDFromCommitMsg(msg string) (string, error) {
-	matches := changeIDRegex.FindAllStringSubmatch(msg, -1)
-	if len(matches) != 1 || len(matches[0]) != 2 {
-		return "", fmt.Errorf("failed to find Change-Id in commit message")
-	}
-	return matches[0][1], nil
-}
-
-type errorList struct {
-	mu   sync.Mutex
-	errs []error
-}
-
-func (e *errorList) Add(err *error) {
-	if *err == nil {
-		return
-	}
-	e.mu.Lock()
-	e.errs = append(e.errs, *err)
-	e.mu.Unlock()
-}
-
-func (e *errorList) Error() string {
-	panic("do not use; inspect list of errors")
-}
-
-func (e *errorList) Err() error {
-	if len(e.errs) == 0 {
-		return nil
-	}
-	return e
 }

--- a/cmd/cueckoo/cmd/testdata/runtrybot.golden
+++ b/cmd/cueckoo/cmd/testdata/runtrybot.golden
@@ -1,5 +1,5 @@
 {
-  "event_type": "hello",
+  "event_type": "trybot run for ref",
   "client_payload": {
     "type": "runtrybot",
     "payload": {

--- a/cmd/cueckoo/cmd/testdata/unity_cl.golden
+++ b/cmd/cueckoo/cmd/testdata/unity_cl.golden
@@ -1,0 +1,14 @@
+{
+  "event_type": "unity run for ref",
+  "client_payload": {
+    "type": "unity",
+    "payload": {
+      "cl": {
+        "changeID": "change",
+        "ref": "ref",
+        "commit": "commit"
+      },
+      "versions": "\"ref\""
+    }
+  }
+}

--- a/cmd/cueckoo/cmd/testdata/unity_versions.golden
+++ b/cmd/cueckoo/cmd/testdata/unity_versions.golden
@@ -1,0 +1,10 @@
+{
+  "event_type": "hello",
+  "client_payload": {
+    "type": "unity",
+    "payload": {
+      "cl": null,
+      "versions": "\"v0.3.0-beta.5\""
+    }
+  }
+}

--- a/cmd/cueckoo/cmd/unity.go
+++ b/cmd/cueckoo/cmd/unity.go
@@ -1,0 +1,107 @@
+// Copyright 2021 The CUE Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/v31/github"
+	"github.com/spf13/cobra"
+)
+
+const (
+	flagUnityNormal flagName = "normal"
+)
+
+// newUnityCmd creates a new unity command
+func newUnityCmd(c *Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unity",
+		Short: "run unity against a version of CUE",
+		Long: `
+Usage of unity:
+
+	unity [--normal] [ARGS...]
+
+When run with no arguments, unity derives a revision and change ID for each
+pending commit in the current branch. If multiple pending commits are found,
+you must either specify which commits to run, or specify HEAD to run the
+unity for all of them.
+
+If the --normal flag is provided, then the list of arguments is interpreted as
+versions understood by unity.
+
+unity requires GITHUB_USER and GITHUB_PAT environment variables to be set with
+your GitHub username and personal acccess token respectively. The personal
+access token only requires "public_repo" scope.
+`,
+		RunE: mkRunE(c, unityDef),
+	}
+	cmd.Flags().Bool(string(flagUnityNormal), false, "pass arguments to unity as versions")
+	return cmd
+}
+
+func unityDef(cmd *Command, args []string) error {
+	cfg, err := loadConfig(targetUnity)
+	if err != nil {
+		return err
+	}
+
+	// If we are passed --normal, interpret all args as versions to be passed to
+	// unity
+	if flagUnityNormal.Bool(cmd) {
+		for i, a := range args {
+			args[i] = strconv.Quote(a)
+		}
+		payload, err := buildUnityPayload("Normal unity run", unityPayload{
+			Versions: strings.Join(args, " "),
+		})
+		if err != nil {
+			return err
+		}
+		return cfg.triggerRepositoryDispatch(payload)
+	}
+
+	// Interpret as a request to test CLs
+
+	r := newCLTrigger(cmd, cfg, buildUnityPayloadFromCLTrigger)
+	return r.run()
+}
+
+type unityPayload struct {
+	CL *clTriggerPayload `json:"cl"`
+
+	// Versions is string "list" of versions against
+	// which to run unity, e.g.
+	//
+	//    "\"v0.3.0-beta.5\" \"v0.3.0-beta.4\""
+	//
+	Versions string `json:"versions"`
+}
+
+func buildUnityPayload(msg string, payload unityPayload) (github.DispatchRequestOptions, error) {
+	return buildDispatchPayload(msg, eventTypeUnity, payload)
+}
+
+func buildUnityPayloadFromCLTrigger(payload clTriggerPayload) (github.DispatchRequestOptions, error) {
+	msg := fmt.Sprintf("unity run for %v", payload.Ref)
+	version := strconv.Quote(payload.Ref)
+	return buildDispatchPayload(msg, eventTypeUnity, unityPayload{
+		Versions: version,
+		CL:       &payload,
+	})
+}

--- a/cmd/cueckoo/cmd/util.go
+++ b/cmd/cueckoo/cmd/util.go
@@ -36,6 +36,14 @@ const (
 	eventTypeRuntrybot eventType = "runtrybot"
 	eventTypeMirror    eventType = "mirror"
 	eventTypeImportPR  eventType = "importpr"
+	eventTypeUnity     eventType = "unity"
+)
+
+type target string
+
+const (
+	targetGitHub target = "github"
+	targetUnity  target = "cue-unity"
 )
 
 type repositoryDispatchPayload struct {
@@ -67,7 +75,9 @@ type config struct {
 	gerritClient *gerrit.Client
 }
 
-func loadConfig() (*config, error) {
+// loadConfig loads the repository configuration from codereview.cfg, using
+// gh as the key to find the relevant GitHub information
+func loadConfig(gh target) (*config, error) {
 	var res config
 	rep, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
 		DetectDotGit: true,
@@ -91,10 +101,11 @@ func loadConfig() (*config, error) {
 	if gerritURL == "" {
 		return nil, fmt.Errorf("missing Gerrit server in codereview config")
 	}
-	githubURL := cfg["github"]
+	githubURL := cfg[string(gh)]
 	if githubURL == "" {
 		return nil, fmt.Errorf("missing GitHub server in codereview config")
 	}
+
 	res.gerritURL, err = codereviewcfg.GerritURLToServer(gerritURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derived Gerrit server from %v: %v", gerritURL, err)


### PR DESCRIPTION
Includes a refactor of common CL-based trigger code into a type shared
between unity and runtrybot.