### PR TITLE
cmd/cueckoo: better repository_dispatch message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         os:
         - ubuntu-18.04
         go_version:
-        - 1.15.7
+        - 1.17.3
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code

--- a/cmd/cueckoo/cmd/unity.go
+++ b/cmd/cueckoo/cmd/unity.go
@@ -69,10 +69,11 @@ func unityDef(cmd *Command, args []string) error {
 	// If we are passed --normal, interpret all args as versions to be passed to
 	// unity
 	if flagUnityVersions.Bool(cmd) {
+		unquoted := strings.Join(args, " ")
 		for i, a := range args {
 			args[i] = strconv.Quote(a)
 		}
-		payload, err := buildUnityPayload("Normal unity run", unityPayload{
+		payload, err := buildUnityPayload(fmt.Sprintf("unity run for versions %s", unquoted), unityPayload{
 			Versions: strings.Join(args, " "),
 		})
 		if err != nil {

--- a/internal/ci/workflows.cue
+++ b/internal/ci/workflows.cue
@@ -32,7 +32,7 @@ workflows: [
 }
 
 _#ubuntuLatest: "ubuntu-18.04"
-_#latestGo:     "1.15.7"
+_#latestGo:     "1.17.3"
 
 test: json.#Workflow & {
 	name: "Test"


### PR DESCRIPTION
When a repository_dispatch is triggered, the GitHub Actions UI shows
that message as the title in the workflow list. Previously that message
simply read "Normal unity run" for every cueckoo runtrybot --versions
invocation, thereby making them indistinguishable in the list.

Fix that by adding the list of versions supplied as part of the title.