### PR TITLE
cmd/cueckoo: use "get CL" endpoint with unique change IDs, plus other improvements

### DIFF
--- a/cmd/cueckoo/cmd/cltrigger.go
+++ b/cmd/cueckoo/cmd/cltrigger.go
@@ -233,10 +233,15 @@ func (c *cltrigger) triggerBuild(rev revision) error {
 	}
 
 	return c.builder(clTriggerPayload{
-		ChangeID: rev.changeID,
-		Ref:      revision.Ref,
-		Commit:   commit,
-		Branch:   in.Branch,
+		// rev.changeID may be in the unique "project~branch~change_id" form,
+		// and we can't use that form for the workflow trigger payload
+		// as tildes are not allowed in
+		// Use the change ID alone, without any tildes.
+		ChangeID: in.ChangeID,
+
+		Ref:    revision.Ref,
+		Commit: commit,
+		Branch: in.Branch,
 	})
 }
 

--- a/cmd/cueckoo/cmd/importpr.go
+++ b/cmd/cueckoo/cmd/importpr.go
@@ -209,9 +209,13 @@ func importPRDef(c *Command, args []string) error {
 
 func run(ctx context.Context, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("%v: %s", err, out)
+		if err, _ := err.(*exec.ExitError); err != nil {
+			// stderr was captured by Output
+			return "", fmt.Errorf("failed to run %q: %v:\n%s", cmd.Args, err, err.Stderr)
+		}
+		return "", fmt.Errorf("failed to run %q: %v", cmd.Args, err)
 	}
 	return string(out), err
 }


### PR DESCRIPTION
(see commit messages - please do not squash)

